### PR TITLE
Run optimize with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ import ...
 func main() {
     study, _ := goptuna.CreateStudy(...)
 
-    var eg errgroup.Group
+    eg, ctx := errgroup.WithContext(context.Background())
+    study.WithContext(ctx)
     for i := 0; i < 5; i++ {
         eg.Go(func() error {
             return study.Optimize(objective, 100)

--- a/_examples/concurrency/main.go
+++ b/_examples/concurrency/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -31,7 +32,8 @@ func main() {
 		goptuna.StudyOptionSetLogger(logger),
 	)
 
-	var eg errgroup.Group
+	eg, ctx := errgroup.WithContext(context.Background())
+	study.WithContext(ctx)
 	for i := 0; i < 5; i++ {
 		eg.Go(func() error {
 			return study.Optimize(objective, 100)


### PR DESCRIPTION
Like this:

```go
package main

import ...

func main() {
    study, _ := goptuna.CreateStudy(...)

    eg, ctx := errgroup.WithContext(context.Background())
    study.WithContext(ctx)

    for i := 0; i < 5; i++ {
        eg.Go(func() error {
            return study.Optimize(objective, 100)
        })
    }
    if err := eg.Wait(); err != nil { ... }
    ...
}
```

## Checking behavior

```go
package main

import (
	"context"
	"fmt"
	"log"
	"math"
	"os"
	"time"

	"github.com/c-bata/goptuna"
	"github.com/c-bata/goptuna/tpe"
	"go.uber.org/zap"
	"golang.org/x/sync/errgroup"
)

func objective(trial goptuna.Trial) (float64, error) {
	x1, _ := trial.SuggestUniform("x1", -10, 10)
	x2, _ := trial.SuggestUniform("x2", -10, 10)
	time.Sleep(1 * time.Second)
	return math.Pow(x1-2, 2) + math.Pow(x2+5, 2), nil
}

func main() {
	logger, err := zap.NewDevelopment()
	if err != nil {
		os.Exit(1)
	}
	defer logger.Sync()

	study, _ := goptuna.CreateStudy(
		"goptuna-example",
		goptuna.StudyOptionSampler(tpe.NewSampler()),
		goptuna.StudyOptionSetLogger(logger),
	)

	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
	defer cancel()

	eg, ctx := errgroup.WithContext(ctx)
	study.WithContext(ctx)
	for i := 0; i < 4; i++ {
		eg.Go(func() error {
			return study.Optimize(objective, 100)
		})
	}
	if err := eg.Wait(); err != nil {
		log.Println("error", err)
		os.Exit(1)
	}

	v, _ := study.GetBestValue()
	params, _ := study.GetBestParams()
	fmt.Println("best value:", v)
	fmt.Println("best params:", params)
}
```

```
$ go run _examples/concurrency/main.go 
2019-07-26T15:18:36.920+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_0", "state": "Complete", "value": 51.745241726643165, "paramsInIR": "map[x1:-5.100698294124405 x2:-6.151227806501357]"}
2019-07-26T15:18:36.921+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_3", "state": "Complete", "value": 87.32394360203261, "paramsInIR": "map[x1:-2.648255867350829 x2:3.1066430162966476]"}
2019-07-26T15:18:36.921+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_1", "state": "Complete", "value": 113.5843482955552, "paramsInIR": "map[x1:8.903922985882328 x2:3.1191253039081026]"}
2019-07-26T15:18:36.921+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_2", "state": "Complete", "value": 119.71973999401186, "paramsInIR": "map[x1:-8.913123208005992 x2:-4.2103913368681445]"}
2019-07-26T15:18:37.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_6", "state": "Complete", "value": 25.16853774601675, "paramsInIR": "map[x1:6.995605635257469 x2:-4.539063905730342]"}
2019-07-26T15:18:37.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_7", "state": "Complete", "value": 0.03832650787671685, "paramsInIR": "map[x1:2.1816038398071225 x2:-4.926879871143263]"}
2019-07-26T15:18:37.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_5", "state": "Complete", "value": 209.14879265487292, "paramsInIR": "map[x1:-4.228286963890898 x2:8.052096925410094]"}
2019-07-26T15:18:37.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_4", "state": "Complete", "value": 38.05605063130359, "paramsInIR": "map[x1:7.943394262996019 x2:-6.652911148818833]"}
2019-07-26T15:18:38.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_9", "state": "Complete", "value": 134.73204019391721, "paramsInIR": "map[x1:5.741479126079884 x2:5.9878739591890895]"}
2019-07-26T15:18:38.924+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_8", "state": "Complete", "value": 33.827719693154904, "paramsInIR": "map[x1:5.493084783719606 x2:-9.650384756867055]"}
2019-07-26T15:18:38.925+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_10", "state": "Complete", "value": 36.15217547226677, "paramsInIR": "map[x1:-2.8718291656953987 x2:-1.4761589064564156]"}
2019-07-26T15:18:38.925+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_11", "state": "Complete", "value": 3.259194912485546, "paramsInIR": "map[x1:0.20484665763762422 x2:-5.191361934278312]"}
2019-07-26T15:18:39.927+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_12", "state": "Complete", "value": 3.846823121568825, "paramsInIR": "map[x1:0.7736744854853117 x2:-3.4693305863057464]"}
2019-07-26T15:18:39.927+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_15", "state": "Complete", "value": 6.525447987058092, "paramsInIR": "map[x1:1.0133553129560977 x2:-2.6437359552490447]"}
2019-07-26T15:18:39.927+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_13", "state": "Complete", "value": 12.659182233900482, "paramsInIR": "map[x1:-0.07979619937366511 x2:-2.1131972698205823]"}
2019-07-26T15:18:39.927+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_14", "state": "Complete", "value": 11.032603149200579, "paramsInIR": "map[x1:-0.5833380230792917 x2:-7.087814121925933]"}
2019-07-26T15:18:40.930+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_16", "state": "Complete", "value": 272.16954707711227, "paramsInIR": "map[x1:-8.191037878765691 x2:7.973522807266929]"}
2019-07-26T15:18:40.930+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_18", "state": "Complete", "value": 29.0107067070929, "paramsInIR": "map[x1:0.9788254637444638 x2:0.28846946418301567]"}
2019-07-26T15:18:40.930+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_17", "state": "Complete", "value": 63.710775379487266, "paramsInIR": "map[x1:2.824505978135739 x2:2.9392043223175515]"}
2019-07-26T15:18:40.930+0900    INFO    goptuna/study.go:101    Finished trial  {"trialID": "trial_19", "state": "Complete", "value": 5.216558266668871, "paramsInIR": "map[x1:3.2139900402049495 x2:-3.065371754327965]"}
2019/07/26 15:18:40 error context deadline exceeded
exit status 1
```