### PR TITLE
Make TPE faster

### DIFF
--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -448,7 +448,22 @@ func getObservationPairs(study *goptuna.Study, paramName string) ([]float64, [][
 			score0 = math.Inf(-1)
 			score1 = sign * trial.Value
 		} else if trial.State == goptuna.TrialStatePruned {
-			panic("still be unreachable")
+			if len(trial.IntermediateValues) > 0 {
+				var step int
+				var intermediateValue float64
+
+				for key := range trial.IntermediateValues {
+					if key > step {
+						step = key
+						intermediateValue = trial.IntermediateValues[key]
+					}
+				}
+				score0 = float64(-step)
+				score1 = sign * intermediateValue
+			} else {
+				score0 = math.Inf(1)
+				score1 = 0.0
+			}
 		} else {
 			continue
 		}

--- a/tpe/sampler_internal_test.go
+++ b/tpe/sampler_internal_test.go
@@ -3,11 +3,28 @@ package tpe
 import (
 	"errors"
 	"math"
+	"math/rand"
 	"reflect"
 	"testing"
 
 	"github.com/c-bata/goptuna"
 )
+
+func almostEqualFloat64(a, b float64, e float64) bool {
+	if a+e > b && a-e < b {
+		return true
+	}
+	return false
+}
+
+func almostEqualFloat641D(a, b []float64, e float64) bool {
+	for i := range a {
+		if !almostEqualFloat64(a[i], b[i], e) {
+			return false
+		}
+	}
+	return true
+}
 
 func TestGetObservationPairs_MINIMIZE(t *testing.T) {
 	study, err := goptuna.CreateStudy(
@@ -104,6 +121,73 @@ func TestGetObservationPairs_MAXIMIZE(t *testing.T) {
 }
 
 // Following test cases are generated from Optuna's behavior.
+
+func TestSampler_splitObservationPairs(t *testing.T) {
+	type fields struct {
+		NStartupTrials        int
+		NEICandidates         int
+		Gamma                 FuncGamma
+		ParzenEstimatorParams ParzenEstimatorParams
+		rng                   *rand.Rand
+		randomSampler         *goptuna.RandomSearchSampler
+	}
+	type args struct {
+		configVals []float64
+		lossVals   [][2]float64
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantBelow []float64
+		wantAbove []float64
+	}{
+		{
+			name: "test case 1",
+			fields: fields{
+				Gamma: DefaultGamma,
+			},
+			args: args{
+				configVals: []float64{7.515720606531342, 5.350185623031333, 5.124041307972975, 1.4089387361626944, -2.895952062621281, -8.814621912214118, 7.603846274084024, 5.915757103674883, 8.364607575197955, 1.4694727910185534},
+				lossVals: [][2]float64{
+					{math.Inf(-1), 51.07650573447907},
+					{math.Inf(-1), 100.79007507622603},
+					{math.Inf(-1), 20.712990047058412},
+					{math.Inf(-1), 142.49871053544777},
+					{math.Inf(-1), 61.74467260557292},
+					{math.Inf(-1), 116.44303200021926},
+					{math.Inf(-1), 132.8075795417795},
+					{math.Inf(-1), 25.243709057350483},
+					{math.Inf(-1), 141.5303287376019},
+					{math.Inf(-1), 33.64359889992425},
+				},
+			},
+			wantBelow: []float64{5.12404131},
+			wantAbove: []float64{
+				7.51572061, 5.35018562, 1.40893874, -2.89595206, -8.81462191,
+				7.60384627, 5.9157571, 8.36460758, 1.46947279},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Sampler{
+				numberOfStartupTrials: tt.fields.NStartupTrials,
+				numberOfEICandidates:  tt.fields.NEICandidates,
+				gamma:                 tt.fields.Gamma,
+				params:                tt.fields.ParzenEstimatorParams,
+				rng:                   tt.fields.rng,
+				randomSampler:         tt.fields.randomSampler,
+			}
+			gotBelow, gotAbove := s.splitObservationPairs(tt.args.configVals, tt.args.lossVals)
+			if !almostEqualFloat641D(gotBelow, tt.wantBelow, 1e-6) {
+				t.Errorf("Sampler.splitObservationPairs() gotBelow = %v, want %v", gotBelow, tt.wantBelow)
+			}
+			if !almostEqualFloat641D(gotAbove, tt.wantAbove, 1e-6) {
+				t.Errorf("Sampler.splitObservationPairs() gotAbove = %v, want %v", gotAbove, tt.wantAbove)
+			}
+		})
+	}
+}
 
 func TestSampler_SampleCategorical(t *testing.T) {
 	d := goptuna.CategoricalDistribution{

--- a/tpe/sampler_internal_test.go
+++ b/tpe/sampler_internal_test.go
@@ -1,101 +1,12 @@
 package tpe
 
 import (
-	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/c-bata/goptuna"
 )
 
-func almostEqualFloat64(a, b float64, e float64) bool {
-	if a+e > b && a-e < b {
-		return true
-	}
-	return false
-}
-
-func almostEqualFloat641D(a, b []float64, e float64) bool {
-	for i := range a {
-		if !almostEqualFloat64(a[i], b[i], e) {
-			return false
-		}
-	}
-	return true
-}
-
 // Following test cases are generated from Optuna's behavior.
-
-func TestSampler_splitObservationPairs(t *testing.T) {
-	type fields struct {
-		NStartupTrials        int
-		NEICandidates         int
-		Gamma                 FuncGamma
-		ParzenEstimatorParams ParzenEstimatorParams
-		rng                   *rand.Rand
-		randomSampler         *goptuna.RandomSearchSampler
-	}
-	type args struct {
-		configIdxs []int
-		configVals []float64
-		lossIdxs   []int
-		lossVals   [][2]float64
-	}
-	tests := []struct {
-		name      string
-		fields    fields
-		args      args
-		wantBelow []float64
-		wantAbove []float64
-	}{
-		{
-			name: "test case 1",
-			fields: fields{
-				Gamma: DefaultGamma,
-			},
-			args: args{
-				configIdxs: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-				configVals: []float64{7.515720606531342, 5.350185623031333, 5.124041307972975, 1.4089387361626944, -2.895952062621281, -8.814621912214118, 7.603846274084024, 5.915757103674883, 8.364607575197955, 1.4694727910185534},
-				lossIdxs:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-				lossVals: [][2]float64{
-					{math.Inf(-1), 51.07650573447907},
-					{math.Inf(-1), 100.79007507622603},
-					{math.Inf(-1), 20.712990047058412},
-					{math.Inf(-1), 142.49871053544777},
-					{math.Inf(-1), 61.74467260557292},
-					{math.Inf(-1), 116.44303200021926},
-					{math.Inf(-1), 132.8075795417795},
-					{math.Inf(-1), 25.243709057350483},
-					{math.Inf(-1), 141.5303287376019},
-					{math.Inf(-1), 33.64359889992425},
-				},
-			},
-			wantBelow: []float64{5.12404131},
-			wantAbove: []float64{
-				7.51572061, 5.35018562, 1.40893874, -2.89595206, -8.81462191,
-				7.60384627, 5.9157571, 8.36460758, 1.46947279},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Sampler{
-				numberOfStartupTrials: tt.fields.NStartupTrials,
-				numberOfEICandidates:  tt.fields.NEICandidates,
-				gamma:                 tt.fields.Gamma,
-				params:                tt.fields.ParzenEstimatorParams,
-				rng:                   tt.fields.rng,
-				randomSampler:         tt.fields.randomSampler,
-			}
-			gotBelow, gotAbove := s.splitObservationPairs(tt.args.configIdxs, tt.args.configVals, tt.args.lossIdxs, tt.args.lossVals)
-			if !almostEqualFloat641D(gotBelow, tt.wantBelow, 1e-4) {
-				t.Errorf("Sampler.splitObservationPairs() gotBelow = %v, want %v", gotBelow, tt.wantBelow)
-			}
-			if !almostEqualFloat641D(gotAbove, tt.wantAbove, 1e-4) {
-				t.Errorf("Sampler.splitObservationPairs() gotAbove = %v, want %v", gotAbove, tt.wantAbove)
-			}
-		})
-	}
-}
 
 func TestSampler_SampleCategorical(t *testing.T) {
 	d := goptuna.CategoricalDistribution{

--- a/tpe/sampler_internal_test.go
+++ b/tpe/sampler_internal_test.go
@@ -1,10 +1,60 @@
 package tpe
 
 import (
+	"errors"
+	"math"
+	"reflect"
 	"testing"
 
 	"github.com/c-bata/goptuna"
 )
+
+func TestGetObservationPairs(t *testing.T) {
+	study, err := goptuna.CreateStudy(
+		"", goptuna.StudyOptionIgnoreObjectiveErr(true),
+		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize))
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+		return
+	}
+	err = study.Optimize(func(trial goptuna.Trial) (float64, error) {
+		x, _ := trial.SuggestInt("x", 5, 5)
+		number, _ := trial.Number()
+		if number == 0 {
+			return float64(x), nil
+		} else if number == 1 {
+			_ = trial.Report(1, 4)
+			_ = trial.Report(2, 7)
+			return 0.0, goptuna.ErrTrialPruned
+		} else if number == 2 {
+			return 0.0, goptuna.ErrTrialPruned
+		} else {
+			return 0.0, errors.New("runtime error")
+		}
+	}, 4)
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+		return
+	}
+
+	values, scores, err := getObservationPairs(study, "x")
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+	}
+
+	expectedValues := []float64{5.0, 5.0, 5.0}
+	if !reflect.DeepEqual(values, expectedValues) {
+		t.Errorf("should be %v, but got %v", expectedValues, values)
+	}
+	expectedScores := [][2]float64{
+		{math.Inf(-1), 5},
+		{-7, 2},
+		{math.Inf(1), 0},
+	}
+	if !reflect.DeepEqual(scores, expectedScores) {
+		t.Errorf("should be %v, but got %v", expectedScores, scores)
+	}
+}
 
 // Following test cases are generated from Optuna's behavior.
 

--- a/tpe/sampler_internal_test.go
+++ b/tpe/sampler_internal_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/c-bata/goptuna"
 )
 
-func TestGetObservationPairs(t *testing.T) {
+func TestGetObservationPairs_MINIMIZE(t *testing.T) {
 	study, err := goptuna.CreateStudy(
 		"", goptuna.StudyOptionIgnoreObjectiveErr(true),
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize))
@@ -49,6 +49,53 @@ func TestGetObservationPairs(t *testing.T) {
 	expectedScores := [][2]float64{
 		{math.Inf(-1), 5},
 		{-7, 2},
+		{math.Inf(1), 0},
+	}
+	if !reflect.DeepEqual(scores, expectedScores) {
+		t.Errorf("should be %v, but got %v", expectedScores, scores)
+	}
+}
+
+func TestGetObservationPairs_MAXIMIZE(t *testing.T) {
+	study, err := goptuna.CreateStudy(
+		"", goptuna.StudyOptionIgnoreObjectiveErr(true),
+		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMaximize))
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+		return
+	}
+	err = study.Optimize(func(trial goptuna.Trial) (float64, error) {
+		x, _ := trial.SuggestInt("x", 5, 5)
+		number, _ := trial.Number()
+		if number == 0 {
+			return float64(x), nil
+		} else if number == 1 {
+			_ = trial.Report(1, 4)
+			_ = trial.Report(2, 7)
+			return 0.0, goptuna.ErrTrialPruned
+		} else if number == 2 {
+			return 0.0, goptuna.ErrTrialPruned
+		} else {
+			return 0.0, errors.New("runtime error")
+		}
+	}, 4)
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+		return
+	}
+
+	values, scores, err := getObservationPairs(study, "x")
+	if err != nil {
+		t.Errorf("should be nil, but got %s", err)
+	}
+
+	expectedValues := []float64{5.0, 5.0, 5.0}
+	if !reflect.DeepEqual(values, expectedValues) {
+		t.Errorf("should be %v, but got %v", expectedValues, values)
+	}
+	expectedScores := [][2]float64{
+		{math.Inf(-1), -5},
+		{-7, -2},
 		{math.Inf(1), 0},
 	}
 	if !reflect.DeepEqual(scores, expectedScores) {


### PR DESCRIPTION
This change make TPE sampler 30% faster in Goptuna and makes the implementation simplified. I will merge this if the original pull request of optuna is merged.

See https://github.com/pfnet/optuna/pull/466.

TODO:

* [x] apply the change
* [x] add tests