### PR TITLE
Provide GetContext from Trial object for handling signals.

### DIFF
--- a/_examples/signalhandling/check.sh
+++ b/_examples/signalhandling/check.sh
@@ -8,9 +8,12 @@ rm db.sqlite3
 
 gtimeout 6 go run ${DIR}/main.go sqlite3 db.sqlite3  # brew install coreutils
 
+echo ""
+echo "*** check trials ***"
+echo ""
+
 sqlite3 db.sqlite3 <<END_SQL
 .header on
 .mode column
-.tables
 select * from trials;
 END_SQL

--- a/_examples/signalhandling/check.sh
+++ b/_examples/signalhandling/check.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+export GO111MODULE=on
+DIR=$(cd $(dirname $0); pwd)
+REPOSITORY_ROOT=$(cd $(dirname $(dirname $(dirname $0))); pwd)
+
+rm db.sqlite3
+
+gtimeout 6 go run ${DIR}/main.go sqlite3 db.sqlite3  # brew install coreutils
+
+sqlite3 db.sqlite3 <<END_SQL
+.header on
+.mode column
+.tables
+select * from trials;
+END_SQL

--- a/_examples/signalhandling/main.go
+++ b/_examples/signalhandling/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/c-bata/goptuna"
+	"github.com/c-bata/goptuna/rdb"
+	"github.com/jinzhu/gorm"
+	"go.uber.org/zap"
+
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+func objective(trial goptuna.Trial) (float64, error) {
+	ctx := trial.GetContext()
+
+	x1, _ := trial.SuggestUniform("x1", -10, 10)
+	x2, _ := trial.SuggestUniform("x2", -10, 10)
+
+	cmd := exec.CommandContext(ctx, "sleep", "1")
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("hooked?", trial.ID)
+		return -1, err
+	}
+	return math.Pow(x1-2, 2) + math.Pow(x2+5, 2), nil
+}
+
+func main() {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		os.Exit(1)
+	}
+	defer logger.Sync()
+
+	db, err := gorm.Open("sqlite3", "db.sqlite3")
+	if err != nil {
+		logger.Fatal("failed to open db", zap.Error(err))
+	}
+	defer db.Close()
+	rdb.RunAutoMigrate(db)
+
+	// create a context with cancel function
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// handle signal
+	signalch := make(chan os.Signal, 1)
+	defer close(signalch)
+	signal.Notify(signalch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		sig, ok := <-signalch
+		if !ok {
+			return
+		}
+		logger.Error("Catch a kill signal",
+			zap.String("signal", sig.String()))
+		cancel()
+	}()
+
+	study, err := goptuna.CreateStudy(
+		"goptuna-example",
+		goptuna.StudyOptionStorage(rdb.NewStorage(db)),
+		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionSetLogger(logger),
+	)
+	if err != nil {
+		logger.Fatal("failed to create study", zap.Error(err))
+	}
+	study.WithContext(ctx)
+
+	err = study.Optimize(objective, 10)
+	if err != nil {
+		logger.Fatal("got error while run optimize", zap.Error(err))
+	}
+
+	v, _ := study.GetBestValue()
+	fmt.Println("Best evaluation value:", v)
+}

--- a/_examples/signalhandling/main.go
+++ b/_examples/signalhandling/main.go
@@ -27,7 +27,6 @@ func objective(trial goptuna.Trial) (float64, error) {
 	cmd := exec.CommandContext(ctx, "sleep", "1")
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println("hooked?", trial.ID)
 		return -1, err
 	}
 	return math.Pow(x1-2, 2) + math.Pow(x2+5, 2), nil

--- a/study.go
+++ b/study.go
@@ -144,7 +144,11 @@ func (s *Study) Optimize(objective FuncObjective, evaluateMax int) error {
 		if s.ctx != nil {
 			select {
 			case <-s.ctx.Done():
-				return s.ctx.Err()
+				err := s.ctx.Err()
+				if err != nil && s.logger != nil {
+					s.logger.Debug("context is canceled", zap.Error(err))
+				}
+				return err
 			default:
 				// do nothing
 			}

--- a/trial.go
+++ b/trial.go
@@ -1,6 +1,9 @@
 package goptuna
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 //go:generate stringer -trimprefix TrialState -output stringer_trial_state.go -type=TrialState
 
@@ -161,4 +164,9 @@ func (t *Trial) GetUserAttrs() (map[string]string, error) {
 // GetSystemAttrs to store the value for the system.
 func (t *Trial) GetSystemAttrs() (map[string]string, error) {
 	return t.Study.Storage.GetTrialSystemAttrs(t.ID)
+}
+
+// GetContext returns a context which is registered at 'study.WithContext()'.
+func (t *Trial) GetContext() context.Context {
+	return t.Study.ctx
 }


### PR DESCRIPTION
Provide `GetContext` from Trial to set `FAIL` status even if goptuna program catch a kill signal.

```console
$ ./_examples/signalhandling/check.sh 
2019-08-15T01:03:19.642+0900    INFO    goptuna/study.go:81     Trial finished  {"trialID": 1, "state": "Complete", "evaluationValue": 47.67429274143393}
2019-08-15T01:03:20.662+0900    INFO    goptuna/study.go:81     Trial finished  {"trialID": 2, "state": "Complete", "evaluationValue": 16.564974686882508}
2019-08-15T01:03:21.684+0900    INFO    goptuna/study.go:81     Trial finished  {"trialID": 3, "state": "Complete", "evaluationValue": 22.229764449254283}
2019-08-15T01:03:22.725+0900    INFO    goptuna/study.go:81     Trial finished  {"trialID": 4, "state": "Complete", "evaluationValue": 132.16017574715212}
2019-08-15T01:03:23.035+0900    ERROR   signalhandling/main.go:62       Catch a kill signal     {"signal": "terminated"}
main.main.func1
        /Users/c-bata/go/src/github.com/c-bata/goptuna/_examples/signalhandling/main.go:62
hooked? 5
2019-08-15T01:03:23.035+0900    INFO    goptuna/study.go:81     Trial finished  {"trialID": 5, "state": "Fail", "evaluationValue": -1, "error": "signal: terminated"}
2019-08-15T01:03:23.038+0900    DEBUG   goptuna/study.go:149    context is canceled     {"error": "context canceled"}
2019-08-15T01:03:23.038+0900    FATAL   signalhandling/main.go:80       got error while run optimize    {"error": "context canceled"}
main.main
        /Users/c-bata/go/src/github.com/c-bata/goptuna/_examples/signalhandling/main.go:80
runtime.main
        /usr/local/Cellar/go/1.12.2/libexec/src/runtime/proc.go:200
studies                  trial_params             trial_values           
study_system_attributes  trial_system_attributes  trials                 
study_user_attributes    trial_user_attributes  
trial_id    study_id    state       value             datetime_start                    datetime_complete               
----------  ----------  ----------  ----------------  --------------------------------  --------------------------------
1           1           COMPLETE    47.6742927414339  2019-08-15 01:03:18.629699+09:00  2019-08-15 01:03:19.646497+09:00
2           1           COMPLETE    16.5649746868825  2019-08-15 01:03:19.647904+09:00  2019-08-15 01:03:20.665832+09:00
3           1           COMPLETE    22.2297644492543  2019-08-15 01:03:20.667917+09:00  2019-08-15 01:03:21.688073+09:00
4           1           COMPLETE    132.160175747152  2019-08-15 01:03:21.689128+09:00  2019-08-15 01:03:22.728232+09:00
5           1           FAIL        0.0               2019-08-15 01:03:22.728994+09:00  2019-08-15 01:03:23.037161+09:00
```
