### PR TITLE
Wrap creating trial with transaction

### DIFF
--- a/rdb/storage.go
+++ b/rdb/storage.go
@@ -232,16 +232,6 @@ func (s *Storage) CreateNewTrialID(studyID int) (int, error) {
 	return trial.ID, err
 }
 
-func (s *Storage) createNewTrialNumber(studyID int, trialID int) (int, error) {
-	var number int
-	err := s.db.Model(&trialModel{}).Where("study_id = ?", studyID).Count(&number).Error
-	if err != nil {
-		return -1, err
-	}
-	err = s.SetTrialSystemAttr(trialID, "_number", strconv.Itoa(number))
-	return number, err
-}
-
 // SetTrialValue sets the value of trial.
 func (s *Storage) SetTrialValue(trialID int, value float64) error {
 	tx := s.db.Begin()


### PR DESCRIPTION
Add transaction while creating trial object.

```
$ ./goptuna-libffm 
2019-08-15T10:03:30.527Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 1, "state": "Fail", "evaluationValue": 
-1, "error": "number is not exist in system attrs"}
2019-08-15T10:03:30.545Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 14, "state": "Fail", "evaluationValue":
 -1, "error": "number is not exist in system attrs"}
2019-08-15T10:04:07.814Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 6, "state": "Complete", "evaluationValu
e": 0.632122}
2019-08-15T10:04:16.892Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 8, "state": "Complete", "evaluationValu
e": 0.674938}
2019-08-15T10:04:34.704Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 26, "state": "Complete", "evaluationVal
ue": 0.692932}
2019-08-15T10:04:54.424Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 18, "state": "Complete", "evaluationVal
ue": 0.308336}
2019-08-15T10:05:03.390Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 23, "state": "Complete", "evaluationVal
ue": 0.304476}
2019-08-15T10:05:10.247Z        INFO    goptuna@v0.0.5-0.20190815095903-605c3abb7c88/study.go:81        Trial finished  {"trialID": 16, "state": "Complete", "evaluationVal
ue": 0.303805}
```