### PR TITLE
Add InTrialStudy for safety access to a study instance inside a trial.

### DIFF
--- a/medianstopping/percentile_test.go
+++ b/medianstopping/percentile_test.go
@@ -19,7 +19,7 @@ func TestPercentilePruner_PruneWithOneTrial(t *testing.T) {
 	}
 
 	trial := goptuna.Trial{
-		Study: study,
+		Study: goptuna.ToInTrialStudy(study),
 		ID:    trialID,
 	}
 	err = trial.Report(1, 1)
@@ -159,6 +159,7 @@ func TestPercentilePruner_Prune(t *testing.T) {
 				t.Errorf("should be err=nil, but got %s", err)
 				return
 			}
+			inTrialStudy := goptuna.ToInTrialStudy(study)
 			for _, v := range tt.intermediateValues {
 				trialID, err := study.Storage.CreateNewTrialID(study.ID)
 				if err != nil {
@@ -166,7 +167,7 @@ func TestPercentilePruner_Prune(t *testing.T) {
 					return
 				}
 				trial := goptuna.Trial{
-					Study: study,
+					Study: inTrialStudy,
 					ID:    trialID,
 				}
 				err = trial.Report(v, 1)
@@ -194,7 +195,7 @@ func TestPercentilePruner_Prune(t *testing.T) {
 				return
 			}
 			trial := goptuna.Trial{
-				Study: study,
+				Study: inTrialStudy,
 				ID:    trialID,
 			}
 			prune, err := p.Prune(study.Storage, study.ID, trialID, 1)

--- a/sampler.go
+++ b/sampler.go
@@ -10,7 +10,7 @@ import (
 // Sampler returns the next search points
 type Sampler interface {
 	// Sample a parameter for a given distribution.
-	Sample(*Study, FrozenTrial, string, interface{}) (float64, error)
+	Sample(*InTrialStudy, FrozenTrial, string, interface{}) (float64, error)
 }
 
 var _ Sampler = &RandomSearchSampler{}
@@ -44,7 +44,7 @@ func NewRandomSearchSampler(opts ...RandomSearchSamplerOption) *RandomSearchSamp
 
 // Sample a parameter for a given distribution.
 func (s *RandomSearchSampler) Sample(
-	study *Study,
+	study *InTrialStudy,
 	trial FrozenTrial,
 	paramName string,
 	paramDistribution interface{},

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -69,6 +69,7 @@ func TestRandomSearchSampler_SampleLogUniform(t *testing.T) {
 		High: 1,
 	}
 
+	inTrialStudy := goptuna.ToInTrialStudy(study)
 	points := make([]float64, 100)
 	for i := 0; i < 100; i++ {
 		trialID, err := study.Storage.CreateNewTrialID(study.ID)
@@ -81,7 +82,7 @@ func TestRandomSearchSampler_SampleLogUniform(t *testing.T) {
 			t.Errorf("should not be err, but got %s", err)
 			return
 		}
-		sampled, err := study.Sampler.Sample(study, trial, "x", distribution)
+		sampled, err := study.Sampler.Sample(inTrialStudy, trial, "x", distribution)
 		if err != nil {
 			t.Errorf("should not be err, but got %s", err)
 			return
@@ -123,6 +124,7 @@ func TestRandomSearchSampler_SampleDiscreteUniform(t *testing.T) {
 	}
 
 	points := make([]float64, 100)
+	inTrialStudy := goptuna.ToInTrialStudy(study)
 	for i := 0; i < 100; i++ {
 		trialID, err := study.Storage.CreateNewTrialID(study.ID)
 		if err != nil {
@@ -134,7 +136,7 @@ func TestRandomSearchSampler_SampleDiscreteUniform(t *testing.T) {
 			t.Errorf("should not be err, but got %s", err)
 			return
 		}
-		sampled, err := study.Sampler.Sample(study, trial, "x", distribution)
+		sampled, err := study.Sampler.Sample(inTrialStudy, trial, "x", distribution)
 		if err != nil {
 			t.Errorf("should not be err, but got %s", err)
 			return

--- a/study.go
+++ b/study.go
@@ -256,7 +256,7 @@ func (s *InTrialStudy) Direction() (StudyDirection, error) {
 }
 
 // Trials returns all trials.
-func (s *InTrialStudy) Trials() ([]FrozenTrial, error) {
+func (s *InTrialStudy) GetTrials() ([]FrozenTrial, error) {
 	return s.Storage.GetAllTrials(s.ID)
 }
 

--- a/study.go
+++ b/study.go
@@ -67,7 +67,7 @@ func (s *Study) runTrial(objective FuncObjective) error {
 	}
 
 	trial := Trial{
-		Study: s,
+		Study: ToInTrialStudy(s),
 		ID:    trialID,
 	}
 
@@ -210,7 +210,11 @@ func ToInTrialStudy(study *Study) *InTrialStudy {
 	return &InTrialStudy{
 		ID:      study.ID,
 		Name:    study.Name,
+		Sampler: study.Sampler,
 		Storage: study.Storage,
+		Pruner:  study.Pruner,
+		Logger:  study.logger,
+		ctx:     study.ctx,
 	}
 }
 
@@ -225,6 +229,10 @@ type InTrialStudy struct {
 	ID      int
 	Name    string
 	Storage Storage
+	Sampler Sampler
+	Pruner  Pruner
+	Logger  *zap.Logger
+	ctx     context.Context
 }
 
 // BestTrial returns the best trial in the InTrialStudy.

--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -500,7 +500,9 @@ func (s *Sampler) Sample(
 
 func getObservationPairs(study *goptuna.Study, paramName string) ([]float64, [][2]float64, error) {
 	var sign float64 = 1
-	if study.Direction() == goptuna.StudyDirectionMaximize {
+	if direction, err := study.Direction(); err != nil {
+		return nil, nil, err
+	} else if direction == goptuna.StudyDirectionMaximize {
 		sign = -1
 	}
 

--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -463,7 +463,7 @@ func (s *Sampler) sampleCategorical(distribution goptuna.CategoricalDistribution
 
 // Sample a parameter for a given distribution.
 func (s *Sampler) Sample(
-	study *goptuna.Study,
+	study *goptuna.InTrialStudy,
 	trial goptuna.FrozenTrial,
 	paramName string,
 	paramDistribution interface{},
@@ -498,7 +498,7 @@ func (s *Sampler) Sample(
 	return 0, goptuna.ErrUnknownDistribution
 }
 
-func getObservationPairs(study *goptuna.Study, paramName string) ([]float64, [][2]float64, error) {
+func getObservationPairs(study *goptuna.InTrialStudy, paramName string) ([]float64, [][2]float64, error) {
 	var sign float64 = 1
 	if direction, err := study.Direction(); err != nil {
 		return nil, nil, err

--- a/tpe/sampler_test.go
+++ b/tpe/sampler_test.go
@@ -121,6 +121,7 @@ func TestSampler_SampleLogUniform(t *testing.T) {
 		High: 1,
 	}
 
+	inTrialStudy := goptuna.ToInTrialStudy(study)
 	points := make([]float64, 100)
 	for i := 0; i < 100; i++ {
 		trialID, err := study.Storage.CreateNewTrialID(study.ID)
@@ -133,7 +134,7 @@ func TestSampler_SampleLogUniform(t *testing.T) {
 			t.Errorf("should not be err, but got %s", err)
 			return
 		}
-		sampled, err := study.Sampler.Sample(study, trial, "x", distribution)
+		sampled, err := study.Sampler.Sample(inTrialStudy, trial, "x", distribution)
 		if err != nil {
 			t.Errorf("should not be err, but got %s", err)
 			return
@@ -174,6 +175,7 @@ func TestSampler_SampleDiscreteUniform(t *testing.T) {
 		Q:    0.1,
 	}
 
+	inTrialStudy := goptuna.ToInTrialStudy(study)
 	points := make([]float64, 100)
 	for i := 0; i < 100; i++ {
 		trialID, err := study.Storage.CreateNewTrialID(study.ID)
@@ -186,7 +188,7 @@ func TestSampler_SampleDiscreteUniform(t *testing.T) {
 			t.Errorf("should not be err, but got %s", err)
 			return
 		}
-		sampled, err := study.Sampler.Sample(study, trial, "x", distribution)
+		sampled, err := study.Sampler.Sample(inTrialStudy, trial, "x", distribution)
 		if err != nil {
 			t.Errorf("should not be err, but got %s", err)
 			return
@@ -239,7 +241,8 @@ func TestGetObservationPairs_MINIMIZE(t *testing.T) {
 		return
 	}
 
-	values, scores, err := tpe.ExportGetObservationPairs(study, "x")
+	inTrialStudy := goptuna.ToInTrialStudy(study)
+	values, scores, err := tpe.ExportGetObservationPairs(inTrialStudy, "x")
 	if err != nil {
 		t.Errorf("should be nil, but got %s", err)
 	}
@@ -286,7 +289,8 @@ func TestGetObservationPairs_MAXIMIZE(t *testing.T) {
 		return
 	}
 
-	values, scores, err := tpe.ExportGetObservationPairs(study, "x")
+	inTrialStudy := goptuna.ToInTrialStudy(study)
+	values, scores, err := tpe.ExportGetObservationPairs(inTrialStudy, "x")
 	if err != nil {
 		t.Errorf("should be nil, but got %s", err)
 	}

--- a/trial.go
+++ b/trial.go
@@ -45,7 +45,8 @@ func (t *Trial) suggest(name string, distribution interface{}) (float64, error) 
 		return 0.0, err
 	}
 
-	v, err := t.Study.Sampler.Sample(t.Study, trial, name, distribution)
+	inTrialStudy := ToInTrialStudy(t.Study)
+	v, err := t.Study.Sampler.Sample(inTrialStudy, trial, name, distribution)
 	if err != nil {
 		return 0.0, err
 	}

--- a/trial.go
+++ b/trial.go
@@ -33,7 +33,7 @@ func (i TrialState) IsFinished() bool {
 // Note that this object is seamlessly instantiated and passed to the objective function behind;
 // hence, in typical use cases, library users do not care about instantiation of this object.
 type Trial struct {
-	Study *Study
+	Study *InTrialStudy
 	ID    int
 	state TrialState
 	value float64
@@ -45,8 +45,7 @@ func (t *Trial) suggest(name string, distribution interface{}) (float64, error) 
 		return 0.0, err
 	}
 
-	inTrialStudy := ToInTrialStudy(t.Study)
-	v, err := t.Study.Sampler.Sample(inTrialStudy, trial, name, distribution)
+	v, err := t.Study.Sampler.Sample(t.Study, trial, name, distribution)
 	if err != nil {
 		return 0.0, err
 	}
@@ -77,8 +76,8 @@ func (t *Trial) Report(value float64, step int) error {
 // the trial should be pruned at the given step.
 func (t *Trial) ShouldPrune(value float64) (bool, error) {
 	if t.Study.Pruner == nil {
-		if t.Study.logger != nil {
-			t.Study.logger.Warn("Although it's not registered pruner, but you calls ShouldPrune method")
+		if t.Study.Logger != nil {
+			t.Study.Logger.Warn("Although it's not registered pruner, but you calls ShouldPrune method")
 		}
 		return false, nil
 	}

--- a/trial_test.go
+++ b/trial_test.go
@@ -163,7 +163,7 @@ func TestTrial_UserAttrs(t *testing.T) {
 		return
 	}
 	trial := goptuna.Trial{
-		Study: study,
+		Study: goptuna.ToInTrialStudy(study),
 		ID:    trialID,
 	}
 
@@ -202,7 +202,7 @@ func TestTrial_SystemAttrs(t *testing.T) {
 		return
 	}
 	trial := goptuna.Trial{
-		Study: study,
+		Study: goptuna.ToInTrialStudy(study),
 		ID:    trialID,
 	}
 


### PR DESCRIPTION
InTrialStudy is added at https://github.com/pfnet/optuna/pull/380. Optuna currently passes it to sampler (and new pruner interface accept it).