### PR TITLE
Provide option for SuccessiveHalvingPruner.

### DIFF
--- a/successivehalving/option.go
+++ b/successivehalving/option.go
@@ -1,0 +1,28 @@
+package successivehalving
+
+// Option to pass the custom option
+type Option func(pruner *Pruner) error
+
+// OptionSetMinResource to set the minimum resource.
+func OptionSetMinResource(minResource int) Option {
+	return func(p *Pruner) error {
+		p.MinResource = minResource
+		return nil
+	}
+}
+
+// OptionSetReductionFactor to set the reduction factor.
+func OptionSetReductioinFactor(reductionFactor int) Option {
+	return func(p *Pruner) error {
+		p.ReductionFactor = reductionFactor
+		return nil
+	}
+}
+
+// OptionSetMinEarlyStoppingRate to set the minimum value of the early stopping rate.
+func OptionSetMinEarlyStoppingRate(minEarlyStoppingRate int) Option {
+	return func(p *Pruner) error {
+		p.MinEarlyStoppingRate = minEarlyStoppingRate
+		return nil
+	}
+}

--- a/successivehalving/pruner_test.go
+++ b/successivehalving/pruner_test.go
@@ -27,7 +27,7 @@ func TestOptunaPruner_IntermediateValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pruner := &successivehalving.OptunaPruner{
+			pruner := &successivehalving.Pruner{
 				MinResource:          1,
 				ReductionFactor:      2,
 				MinEarlyStoppingRate: 0,
@@ -106,7 +106,7 @@ func TestOptunaPruner_IntermediateValues(t *testing.T) {
 }
 
 func TestOptunaPruner_RungCheck(t *testing.T) {
-	pruner := &successivehalving.OptunaPruner{
+	pruner := &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -236,7 +236,7 @@ func TestOptunaPruner_RungCheck(t *testing.T) {
 }
 
 func TestOptunaPruner_FirstTrialIsNotPruned(t *testing.T) {
-	pruner := &successivehalving.OptunaPruner{
+	pruner := &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -318,7 +318,7 @@ func TestOptunaPruner_MinResource(t *testing.T) {
 	}
 
 	// min_resource=1: The rung 0 ends at step 1.
-	pruner := &successivehalving.OptunaPruner{
+	pruner := &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -355,7 +355,7 @@ func TestOptunaPruner_MinResource(t *testing.T) {
 	}
 
 	// min_resource=2: The rung 0 ends at step 2.
-	pruner = &successivehalving.OptunaPruner{
+	pruner = &successivehalving.Pruner{
 		MinResource:          2,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -425,7 +425,7 @@ func TestOptunaPruner_ReductionFactor(t *testing.T) {
 	}
 
 	// reduction_factor=2: The rung 0 ends at step 1.
-	pruner := &successivehalving.OptunaPruner{
+	pruner := &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -461,7 +461,7 @@ func TestOptunaPruner_ReductionFactor(t *testing.T) {
 	}
 
 	// reduction_factor=3: The rung 1 ends at step 3.
-	pruner = &successivehalving.OptunaPruner{
+	pruner = &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      3,
 		MinEarlyStoppingRate: 0,
@@ -553,7 +553,7 @@ func TestOptunaPruner_MinEarlyStoppingRate(t *testing.T) {
 	}
 
 	// min_early_stopping_rate=0: The rung 0 ends at step 1.
-	pruner := &successivehalving.OptunaPruner{
+	pruner := &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 0,
@@ -586,7 +586,7 @@ func TestOptunaPruner_MinEarlyStoppingRate(t *testing.T) {
 	}
 
 	// min_early_stopping_rate=1: The rung 0 ends at step 2.
-	pruner = &successivehalving.OptunaPruner{
+	pruner = &successivehalving.Pruner{
 		MinResource:          1,
 		ReductionFactor:      2,
 		MinEarlyStoppingRate: 1,


### PR DESCRIPTION
I named a component for successive halving `OptunaPruner` because this is optuna flavored version. But I'm planning to switch to the algorithm which is exactly same behavior with original ASHA algorithm by a flag option in this pruner. In this PR, I renamed `successivehalving.OptunaPruner` with `successivehalving.Pruner`. And this adds option for pruner settings.

This includes breaking changes. But the users who use this components are quite few. So I ignore those.