### PR TITLE
Set a seed to inner random sampler of TPE sampler

### DIFF
--- a/tpe/sampler_option.go
+++ b/tpe/sampler_option.go
@@ -1,14 +1,22 @@
 package tpe
 
-import "math/rand"
+import (
+	"math/rand"
+
+	"github.com/c-bata/goptuna"
+)
 
 // SamplerOption is a type of the function to customizing TPE sampler.
 type SamplerOption func(sampler *Sampler)
 
 // SamplerOptionSeed sets seed number.
 func SamplerOptionSeed(seed int64) SamplerOption {
+	randomSampler := goptuna.NewRandomSearchSampler(
+		goptuna.RandomSearchSamplerOptionSeed(seed))
+
 	return func(sampler *Sampler) {
 		sampler.rng = rand.New(rand.NewSource(seed))
+		sampler.randomSampler = randomSampler
 	}
 }
 


### PR DESCRIPTION
Fix a bug of `tpe.SamplerOptionSeed` isn't reflect to its inner random sampler.
Thanks @sile for reporting this bug (refs #64).