### PR TITLE
Fix a bug of TPE optimization on discrete uniform distributions

### DIFF
--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -405,7 +405,9 @@ func (s *Sampler) sampleInt(distribution goptuna.IntUniformDistribution, below, 
 func (s *Sampler) sampleDiscreteUniform(distribution goptuna.DiscreteUniformDistribution, below, above []float64) float64 {
 	q := distribution.Q
 	r := distribution.High - distribution.Low
+
 	// [low, high] is shifted to [0, r] to align sampled values at regular intervals.
+	// See https://github.com/optuna/optuna/pull/917#issuecomment-586114630 for details.
 	low := 0 - 0.5*q
 	high := r + 0.5*q
 

--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -408,6 +408,15 @@ func (s *Sampler) sampleDiscreteUniform(distribution goptuna.DiscreteUniformDist
 	// [low, high] is shifted to [0, r] to align sampled values at regular intervals.
 	low := 0 - 0.5*q
 	high := r + 0.5*q
+
+	// Shift below and above to [0, r]
+	for i := range below {
+		below[i] -= distribution.Low
+	}
+	for i := range above {
+		above[i] -= distribution.Low
+	}
+
 	best := s.sampleNumerical(low, high, below, above, q, false) + distribution.Low
 	return math.Min(math.Max(best, distribution.Low), distribution.High)
 }


### PR DESCRIPTION
See https://github.com/optuna/optuna/pull/917

```python
package main

import (
	"log"
	"math"
	"sync"

	"github.com/c-bata/goptuna"
	"github.com/c-bata/goptuna/tpe"
)

func objective(trial goptuna.Trial) (float64, error) {
	x1, _ := trial.SuggestDiscreteUniform("x1", -10, 10, 2.0)
	x2, _ := trial.SuggestDiscreteUniform("x2", -10, 10, 2.0)
	return math.Pow(x1-8, 2) + math.Pow(x2+8, 2), nil
}

func main() {
	trialchan := make(chan goptuna.FrozenTrial, 8)
	study, err := goptuna.CreateStudy(
		"goptuna-example",
		goptuna.StudyOptionLogger(nil),
		goptuna.StudyOptionSampler(tpe.NewSampler()),
		goptuna.StudyOptionSetTrialNotifyChannel(trialchan),
	)
	if err != nil {
		log.Fatal("failed to create study:", err)
	}

	var wg sync.WaitGroup
	wg.Add(2)
	go func() {
		defer wg.Done()
		err = study.Optimize(objective, 40)
		close(trialchan)
	}()
	go func() {
		defer wg.Done()
		for t := range trialchan {
			log.Println("value", t.Value, "params", t.Params)
		}
	}()
	wg.Wait()

	v, _ := study.GetBestValue()
	params, _ := study.GetBestParams()
	log.Printf("Best evaluation=%f (x1=%f, x2=%f)",
		v, params["x1"].(float64), params["x2"].(float64))
}
```

## Before

```
$ go run _examples/simple_tpe/main.go
2020/02/13 12:23:42 value 8 params map[x1:10 x2:-6]
2020/02/13 12:23:42 value 20 params map[x1:4 x2:-10]
2020/02/13 12:23:42 value 116 params map[x1:-2 x2:-4]
2020/02/13 12:23:42 value 340 params map[x1:-6 x2:4]
2020/02/13 12:23:42 value 0 params map[x1:8 x2:-8]
2020/02/13 12:23:42 value 400 params map[x1:-4 x2:8]
2020/02/13 12:23:42 value 16 params map[x1:8 x2:-4]
2020/02/13 12:23:42 value 40 params map[x1:2 x2:-6]
2020/02/13 12:23:42 value 8 params map[x1:6 x2:-10]
2020/02/13 12:23:42 value 200 params map[x1:6 x2:6]
2020/02/13 12:23:42 value 296 params map[x1:-6 x2:2]
2020/02/13 12:23:42 value 144 params map[x1:-4 x2:-8]
2020/02/13 12:23:42 value 260 params map[x1:-8 x2:-6]
2020/02/13 12:23:42 value 40 params map[x1:2 x2:-6]
2020/02/13 12:23:42 value 80 params map[x1:4 x2:0]
2020/02/13 12:23:42 value 148 params map[x1:-4 x2:-10]
2020/02/13 12:23:42 value 180 params map[x1:-4 x2:-2]
2020/02/13 12:23:42 value 452 params map[x1:-6 x2:8]
2020/02/13 12:23:42 value 400 params map[x1:-8 x2:4]
2020/02/13 12:23:42 value 260 params map[x1:-6 x2:0]
2020/02/13 12:23:42 value 244 params map[x1:-2 x2:4]
2020/02/13 12:23:42 value 136 params map[x1:2 x2:2]
2020/02/13 12:23:42 value 292 params map[x1:2 x2:8]
2020/02/13 12:23:42 value 356 params map[x1:-8 x2:2]
2020/02/13 12:23:42 value 104 params map[x1:-2 x2:-10]
2020/02/13 12:23:42 value 20 params map[x1:4 x2:-6]
2020/02/13 12:23:42 value 648 params map[x1:-10 x2:10]
2020/02/13 12:23:42 value 116 params map[x1:-2 x2:-4]
2020/02/13 12:23:42 value 256 params map[x1:8 x2:8]
2020/02/13 12:23:42 value 208 params map[x1:0 x2:4]
2020/02/13 12:23:42 value 72 params map[x1:2 x2:-2]
2020/02/13 12:23:42 value 100 params map[x1:-2 x2:-8]
2020/02/13 12:23:42 value 288 params map[x1:-4 x2:4]
2020/02/13 12:23:42 value 80 params map[x1:4 x2:0]
2020/02/13 12:23:42 value 100 params map[x1:-2 x2:-8]
2020/02/13 12:23:42 value 144 params map[x1:-4 x2:-8]
2020/02/13 12:23:42 value 260 params map[x1:0 x2:6]
2020/02/13 12:23:42 value 200 params map[x1:-6 x2:-10]
2020/02/13 12:23:42 value 104 params map[x1:-2 x2:-10]
2020/02/13 12:23:42 value 100 params map[x1:-2 x2:-8]
2020/02/13 12:23:42 Best evaluation=0.000000 (x1=8.000000, x2=-8.000000)
```

## After

```
$ go run _examples/simple_tpe/main.go 
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-6]
2020/02/14 16:09:29 value 20 params map[x1:4 x2:-10]
2020/02/14 16:09:29 value 116 params map[x1:-2 x2:-4]
2020/02/14 16:09:29 value 340 params map[x1:-6 x2:4]
2020/02/14 16:09:29 value 0 params map[x1:8 x2:-8]
2020/02/14 16:09:29 value 400 params map[x1:-4 x2:8]
2020/02/14 16:09:29 value 16 params map[x1:8 x2:-4]
2020/02/14 16:09:29 value 40 params map[x1:2 x2:-6]
2020/02/14 16:09:29 value 8 params map[x1:6 x2:-10]
2020/02/14 16:09:29 value 200 params map[x1:6 x2:6]
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-10]
2020/02/14 16:09:29 value 40 params map[x1:10 x2:-2]
2020/02/14 16:09:29 value 20 params map[x1:4 x2:-6]
2020/02/14 16:09:29 value 40 params map[x1:10 x2:-2]
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-6]
2020/02/14 16:09:29 value 260 params map[x1:6 x2:8]
2020/02/14 16:09:29 value 32 params map[x1:4 x2:-4]
2020/02/14 16:09:29 value 4 params map[x1:8 x2:-10]
2020/02/14 16:09:29 value 104 params map[x1:-2 x2:-10]
2020/02/14 16:09:29 value 520 params map[x1:-10 x2:6]
2020/02/14 16:09:29 value 388 params map[x1:0 x2:10]
2020/02/14 16:09:29 value 16 params map[x1:8 x2:-4]
2020/02/14 16:09:29 value 68 params map[x1:10 x2:0]
2020/02/14 16:09:29 value 40 params map[x1:2 x2:-10]
2020/02/14 16:09:29 value 8 params map[x1:6 x2:-10]
2020/02/14 16:09:29 value 64 params map[x1:0 x2:-8]
2020/02/14 16:09:29 value 52 params map[x1:4 x2:-2]
2020/02/14 16:09:29 value 8 params map[x1:6 x2:-6]
2020/02/14 16:09:29 value 4 params map[x1:8 x2:-10]
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-10]
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-6]
2020/02/14 16:09:29 value 8 params map[x1:6 x2:-10]
2020/02/14 16:09:29 value 20 params map[x1:10 x2:-4]
2020/02/14 16:09:29 value 32 params map[x1:4 x2:-4]
2020/02/14 16:09:29 value 4 params map[x1:10 x2:-8]
2020/02/14 16:09:29 value 0 params map[x1:8 x2:-8]
2020/02/14 16:09:29 value 4 params map[x1:8 x2:-10]
2020/02/14 16:09:29 value 64 params map[x1:0 x2:-8]
2020/02/14 16:09:29 value 8 params map[x1:10 x2:-6]
2020/02/14 16:09:29 value 20 params map[x1:4 x2:-10]
2020/02/14 16:09:29 Best evaluation=0.000000 (x1=8.000000, x2=-8.000000)
```