### PR TITLE
Fix IntUniformDistribution.ToExternalRepr()

### DIFF
--- a/distribution.go
+++ b/distribution.go
@@ -92,7 +92,7 @@ const IntUniformDistributionName = "IntUniformDistribution"
 
 // ToExternalRepr to convert internal representation of a parameter value into external representation.
 func (d *IntUniformDistribution) ToExternalRepr(ir float64) interface{} {
-	return int(ir)
+	return int(math.Round(ir))
 }
 
 // Single to test whether the range of this distribution contains just a single value.

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -89,14 +89,20 @@ func TestDistributionToExternalRepresentation(t *testing.T) {
 		{
 			name:         "log uniform distribution",
 			distribution: &goptuna.LogUniformDistribution{Low: 1e-2, High: 1e3},
-			args:         float64(1e2),
-			want:         float64(1e2),
+			args:         1e2,
+			want:         1e2,
 		},
 		{
-			name:         "int uniform distribution",
+			name:         "int uniform distribution 1",
 			distribution: &goptuna.IntUniformDistribution{Low: 0, High: 10},
 			args:         3.0,
 			want:         3,
+		},
+		{
+			name:         "int uniform distribution 2",
+			distribution: &goptuna.IntUniformDistribution{Low: 0, High: 10},
+			args:         1.6,
+			want:         2,
 		},
 		{
 			name:         "step int uniform distribution 1",


### PR DESCRIPTION
Should be rounded off because TPE sampler samples from the following space:

https://github.com/c-bata/goptuna/blob/92b7cc5e398f49a1b0b1cde093037d96d4d1cc8c/tpe/sampler.go#L400-L402