### PR TITLE
Add TPE sampler options

### DIFF
--- a/tpe/sampler_option.go
+++ b/tpe/sampler_option.go
@@ -20,7 +20,53 @@ func SamplerOptionSeed(seed int64) SamplerOption {
 	}
 }
 
-// SamplerOptionGammaFunc sets the gamma function.
+// SamplerOptionConsiderPrior enhance the stability of Parzen estimator
+// by imposing a Gaussian prior when True. The prior is only effective
+// if the sampling distribution is either `UniformDistribution`,
+// `DiscreteUniformDistribution`, `LogUniformDistribution`, or `IntUniformDistribution`.
+func SamplerOptionConsiderPrior(considerPrior bool) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.params.ConsiderPrior = considerPrior
+	}
+}
+
+// SamplerOptionPriorWeight sets the weight of the prior.
+func SamplerOptionPriorWeight(priorWeight float64) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.params.PriorWeight = priorWeight
+	}
+}
+
+// SamplerOptionPriorWeight enable a heuristic to limit the smallest variances
+// of Gaussians used in the Parzen estimator.
+func SamplerOptionConsiderMagicClip(considerMagicClip bool) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.params.ConsiderMagicClip = considerMagicClip
+	}
+}
+
+// SamplerOptionConsiderEndpoints take endpoints of domains into account
+// when calculating variances of Gaussians in Parzen estimator.
+// See the original paper for details on the heuristics to calculate the variances.
+func SamplerOptionConsiderEndpoints(considerEndpoints bool) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.params.ConsiderEndpoints = considerEndpoints
+	}
+}
+
+// SamplerOptionWeights sets the function that takes the number of finished trials
+// and returns a weight for them. See `Making a Science of Model Search: Hyperparameter
+// Optimization in Hundreds of Dimensions for Vision Architectures
+// <http://proceedings.mlr.press/v28/bergstra13.pdf>` for more details.
+func SamplerOptionWeights(weights func(x int) []float64) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.params.Weights = weights
+	}
+}
+
+// SamplerOptionGammaFunc sets the function that takes the number of
+// finished trials and returns the number of trials to form a density
+// function for samples with low grains.
 func SamplerOptionGammaFunc(gamma FuncGamma) SamplerOption {
 	return func(sampler *Sampler) {
 		sampler.gamma = gamma


### PR DESCRIPTION
Add TPE sampler options.

* SamplerOptionConsiderPrior(considerPrior bool)
* SamplerOptionPriorWeight(priorWeight float64)
* SamplerOptionConsiderMagicClip(considerMagicClip bool)
* SamplerOptionConsiderEndpoints(considerEndpoints bool)
* SamplerOptionWeights(weights func(x int) []float64)

refs https://github.com/optuna/optuna/pull/1144