### PR TITLE
Randomize initial mean vector at restart

### DIFF
--- a/cmaes/sampler.go
+++ b/cmaes/sampler.go
@@ -114,7 +114,7 @@ func (s *Sampler) SampleRelative(
 			}
 
 			if s.restartStrategy == restartStrategyIOP && s.optimizer.ShouldStop() {
-				s.nRestarts += 1
+				s.nRestarts++
 				popsize := s.optimizer.PopulationSize() * s.incPopSize
 				s.optimizer, err = s.initOptimizer(searchSpace, orderedKeys,
 					OptimizerOptionPopulationSize(popsize))


### PR DESCRIPTION
Followup for #131. Initial mean is sampled uniformly distributed in the domain.

> For each restart the initial point m is sampled uniformly within the subset bounds [A, B]^n and the initial step-size m^0 is equal to (B-A) / 2.
> https://sci2s.ugr.es/sites/default/files/files/TematicWebSites/EAMHCO/contributionsCEC05/auger05ARCMA.pdf
