### PR TITLE
Rename RandomSearchSampler to RandomSampler with backward compatibility.

### DIFF
--- a/_benchmarks/goptuna_solver/main.go
+++ b/_benchmarks/goptuna_solver/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func randomSampler(seed int64) (*goptuna.Study, error) {
-	s := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(seed))
+	s := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(seed))
 	return goptuna.CreateStudy("example-study",
 		goptuna.StudyOptionSampler(s))
 }
@@ -23,7 +23,7 @@ func tpeSampler(seed int64) (*goptuna.Study, error) {
 }
 
 func cmaSampler(seed int64) (*goptuna.Study, error) {
-	s := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(seed))
+	s := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(seed))
 	rs := cmaes.NewSampler(cmaes.SamplerOptionSeed(seed))
 	return goptuna.CreateStudy("example-study",
 		goptuna.StudyOptionSampler(s),
@@ -31,7 +31,7 @@ func cmaSampler(seed int64) (*goptuna.Study, error) {
 }
 
 func ipopCmaSampler(seed int64) (*goptuna.Study, error) {
-	s := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(seed))
+	s := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(seed))
 	rs := cmaes.NewSampler(cmaes.SamplerOptionSeed(seed),
 		cmaes.SamplerOptionIPop(2))
 	return goptuna.CreateStudy("example-study",
@@ -40,7 +40,7 @@ func ipopCmaSampler(seed int64) (*goptuna.Study, error) {
 }
 
 func bipopCmaSampler(seed int64) (*goptuna.Study, error) {
-	s := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(seed))
+	s := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(seed))
 	rs := cmaes.NewSampler(cmaes.SamplerOptionSeed(seed),
 		cmaes.SamplerOptionBIPop(2))
 	return goptuna.CreateStudy("example-study",

--- a/sampler.go
+++ b/sampler.go
@@ -86,27 +86,27 @@ func IntersectionSearchSpace(study *Study) (map[string]interface{}, error) {
 	return searchSpace, nil
 }
 
-var _ Sampler = &RandomSearchSampler{}
+var _ Sampler = &RandomSampler{}
 
-// RandomSearchSampler for random search
-type RandomSearchSampler struct {
+// RandomSampler for random search
+type RandomSampler struct {
 	rng *rand.Rand
 	mu  sync.Mutex
 }
 
-// RandomSearchSamplerOption is a type of function to set change the option.
-type RandomSearchSamplerOption func(sampler *RandomSearchSampler)
+// RandomSamplerOption is a type of function to set change the option.
+type RandomSamplerOption func(sampler *RandomSampler)
 
-// RandomSearchSamplerOptionSeed sets seed number.
-func RandomSearchSamplerOptionSeed(seed int64) RandomSearchSamplerOption {
-	return func(sampler *RandomSearchSampler) {
+// RandomSamplerOptionSeed sets seed number.
+func RandomSamplerOptionSeed(seed int64) RandomSamplerOption {
+	return func(sampler *RandomSampler) {
 		sampler.rng = rand.New(rand.NewSource(seed))
 	}
 }
 
-// NewRandomSearchSampler implements random search algorithm.
-func NewRandomSearchSampler(opts ...RandomSearchSamplerOption) *RandomSearchSampler {
-	s := &RandomSearchSampler{
+// NewRandomSampler implements random search algorithm.
+func NewRandomSampler(opts ...RandomSamplerOption) *RandomSampler {
+	s := &RandomSampler{
 		rng: rand.New(rand.NewSource(0)),
 	}
 	for _, opt := range opts {
@@ -116,7 +116,7 @@ func NewRandomSearchSampler(opts ...RandomSearchSamplerOption) *RandomSearchSamp
 }
 
 // Sample a parameter for a given distribution.
-func (s *RandomSearchSampler) Sample(
+func (s *RandomSampler) Sample(
 	study *Study,
 	trial FrozenTrial,
 	paramName string,

--- a/sampler.go
+++ b/sampler.go
@@ -170,3 +170,21 @@ func (s *RandomSampler) Sample(
 		return 0.0, errors.New("undefined distribution")
 	}
 }
+
+// RandomSearchSampler for random search
+// Deprecated: this is renamed to RandomSampler.
+type RandomSearchSampler RandomSampler
+
+// RandomSearchSamplerOption is a type of function to set change the option.
+// Deprecated: this is renamed to RandomSamplerOption.
+type RandomSearchSamplerOption RandomSamplerOption
+
+var (
+	// RandomSearchSamplerOptionSeed sets seed number.
+	// Deprecated: this is renamed to RandomSamplerOptionSeed.
+	RandomSearchSamplerOptionSeed = RandomSamplerOptionSeed
+
+	// NewRandomSearchSampler implements random search algorithm.
+	// Deprecated: this is renamed to NewRandomSampler.
+	NewRandomSearchSampler = NewRandomSampler
+)

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/c-bata/goptuna/internal/testutil"
 )
 
-func TestRandomSearchSamplerOptionSeed(t *testing.T) {
+func TestRandomSamplerOptionSeed(t *testing.T) {
 	tests := []struct {
 		name         string
 		distribution interface{}
@@ -34,9 +34,9 @@ func TestRandomSearchSamplerOptionSeed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sampler1 := goptuna.NewRandomSearchSampler()
-			sampler2 := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(2))
-			sampler3 := goptuna.NewRandomSearchSampler(goptuna.RandomSearchSamplerOptionSeed(2))
+			sampler1 := goptuna.NewRandomSampler()
+			sampler2 := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(2))
+			sampler3 := goptuna.NewRandomSampler(goptuna.RandomSamplerOptionSeed(2))
 
 			s1, err := sampler1.Sample(nil, goptuna.FrozenTrial{}, "foo", tt.distribution)
 			if err != nil {
@@ -60,8 +60,8 @@ func TestRandomSearchSamplerOptionSeed(t *testing.T) {
 	}
 }
 
-func TestRandomSearchSampler_SampleLogUniform(t *testing.T) {
-	sampler := goptuna.NewRandomSearchSampler()
+func TestRandomSampler_SampleLogUniform(t *testing.T) {
+	sampler := goptuna.NewRandomSampler()
 	study, err := goptuna.CreateStudy("", goptuna.StudyOptionSampler(sampler))
 	if err != nil {
 		t.Errorf("should not be err, but got %s", err)
@@ -112,8 +112,8 @@ func TestRandomSearchSampler_SampleLogUniform(t *testing.T) {
 	}
 }
 
-func TestRandomSearchSampler_SampleDiscreteUniform(t *testing.T) {
-	sampler := goptuna.NewRandomSearchSampler()
+func TestRandomSampler_SampleDiscreteUniform(t *testing.T) {
+	sampler := goptuna.NewRandomSampler()
 	study, err := goptuna.CreateStudy("", goptuna.StudyOptionSampler(sampler))
 	if err != nil {
 		t.Errorf("should not be err, but got %s", err)
@@ -183,7 +183,7 @@ func (s *queueRelativeSampler) SampleRelative(
 }
 
 func TestRelativeSampler(t *testing.T) {
-	sampler := goptuna.NewRandomSearchSampler()
+	sampler := goptuna.NewRandomSampler()
 	relativeSampler := &queueRelativeSampler{
 		params: []map[string]float64{
 			{
@@ -247,7 +247,7 @@ func TestRelativeSampler(t *testing.T) {
 }
 
 func TestRelativeSampler_UnsupportedSearchSpace(t *testing.T) {
-	sampler := goptuna.NewRandomSearchSampler()
+	sampler := goptuna.NewRandomSampler()
 	relativeSampler := &queueRelativeSampler{
 		params: []map[string]float64{
 			nil,

--- a/study.go
+++ b/study.go
@@ -373,7 +373,7 @@ func CreateStudy(
 	opts ...StudyOption,
 ) (*Study, error) {
 	storage := NewInMemoryStorage()
-	sampler := NewRandomSearchSampler()
+	sampler := NewRandomSampler()
 	study := &Study{
 		ID:              0,
 		Storage:         storage,
@@ -420,7 +420,7 @@ func LoadStudy(
 	opts ...StudyOption,
 ) (*Study, error) {
 	storage := NewInMemoryStorage()
-	sampler := NewRandomSearchSampler()
+	sampler := NewRandomSampler()
 	study := &Study{
 		ID:              0,
 		Storage:         storage,

--- a/study_test.go
+++ b/study_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func ExampleStudy_Optimize() {
-	sampler := goptuna.NewRandomSearchSampler(
-		goptuna.RandomSearchSamplerOptionSeed(0),
+	sampler := goptuna.NewRandomSampler(
+		goptuna.RandomSamplerOptionSeed(0),
 	)
 	study, _ := goptuna.CreateStudy(
 		"example",
@@ -44,7 +44,7 @@ func TestStudy_SystemAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
-		goptuna.StudyOptionSampler(goptuna.NewRandomSearchSampler()),
+		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 
 	err := study.SetSystemAttr("hello", "world")
@@ -134,7 +134,7 @@ func TestStudy_UserAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
-		goptuna.StudyOptionSampler(goptuna.NewRandomSearchSampler()),
+		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 
 	err := study.SetUserAttr("hello", "world")
@@ -163,7 +163,7 @@ func TestStudy_AppendTrial(t *testing.T) {
 	study, err := goptuna.CreateStudy(
 		"example",
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
-		goptuna.StudyOptionSampler(goptuna.NewRandomSearchSampler()),
+		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	if err != nil {
 		t.Errorf("err: %v != nil", err)

--- a/tpe/sampler.go
+++ b/tpe/sampler.go
@@ -59,7 +59,7 @@ type Sampler struct {
 	gamma                 FuncGamma
 	params                ParzenEstimatorParams
 	rng                   *rand.Rand
-	randomSampler         *goptuna.RandomSearchSampler
+	randomSampler         *goptuna.RandomSampler
 	mu                    sync.Mutex
 }
 
@@ -77,7 +77,7 @@ func NewSampler(opts ...SamplerOption) *Sampler {
 			Weights:           DefaultWeights,
 		},
 		rng:           rand.New(rand.NewSource(0)),
-		randomSampler: goptuna.NewRandomSearchSampler(),
+		randomSampler: goptuna.NewRandomSampler(),
 	}
 
 	for _, opt := range opts {

--- a/tpe/sampler_option.go
+++ b/tpe/sampler_option.go
@@ -11,8 +11,8 @@ type SamplerOption func(sampler *Sampler)
 
 // SamplerOptionSeed sets seed number.
 func SamplerOptionSeed(seed int64) SamplerOption {
-	randomSampler := goptuna.NewRandomSearchSampler(
-		goptuna.RandomSearchSamplerOptionSeed(seed))
+	randomSampler := goptuna.NewRandomSampler(
+		goptuna.RandomSamplerOptionSeed(seed))
 
 	return func(sampler *Sampler) {
 		sampler.rng = rand.New(rand.NewSource(seed))

--- a/trial_test.go
+++ b/trial_test.go
@@ -134,8 +134,8 @@ func TestTrial_Suggest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sampler := goptuna.NewRandomSearchSampler(
-				goptuna.RandomSearchSamplerOptionSeed(0),
+			sampler := goptuna.NewRandomSampler(
+				goptuna.RandomSamplerOptionSeed(0),
 			)
 			study, err := goptuna.CreateStudy(tt.name,
 				goptuna.StudyOptionIgnoreError(false),
@@ -155,7 +155,7 @@ func TestTrial_UserAttrs(t *testing.T) {
 		"example",
 		goptuna.StudyOptionStorage(goptuna.NewInMemoryStorage()),
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
-		goptuna.StudyOptionSampler(goptuna.NewRandomSearchSampler()),
+		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	trialID, err := study.Storage.CreateNewTrial(study.ID)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestTrial_SystemAttrs(t *testing.T) {
 		"example",
 		goptuna.StudyOptionStorage(goptuna.NewInMemoryStorage()),
 		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
-		goptuna.StudyOptionSampler(goptuna.NewRandomSearchSampler()),
+		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	trialID, err := study.Storage.CreateNewTrial(study.ID)
 	if err != nil {


### PR DESCRIPTION
RandomSearchSampler is a bit redundant and not consistent with Optuna.

Check other libraries:

* sile/kurobako-go: kurobako-go doesn't refer to RandomSearchSampler.
* Kubeflow/Katib: katib refers to RandomSearchSampler.
    * https://github.com/kubeflow/katib/blob/27658a7c135a6eb30f36e307c8a5ac3407d56694/pkg/suggestion/v1alpha3/goptuna/converter.go#L67-L77
    * https://github.com/kubeflow/katib/blob/27658a7c135a6eb30f36e307c8a5ac3407d56694/pkg/suggestion/v1beta1/goptuna/converter.go#L67-L77