### PR TITLE
Rename study options with backward compatibility.

### DIFF
--- a/_examples/gorgonia_iris/main.go
+++ b/_examples/gorgonia_iris/main.go
@@ -41,7 +41,7 @@ func main() {
 		"gorgonia-iris",
 		goptuna.StudyOptionStorage(storage),
 		goptuna.StudyOptionSampler(tpe.NewSampler()),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMaximize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMaximize),
 	)
 	if err != nil {
 		log.Fatal("failed to create study: ", err)

--- a/_examples/signalhandling/main.go
+++ b/_examples/signalhandling/main.go
@@ -44,7 +44,7 @@ func main() {
 	study, err := goptuna.CreateStudy(
 		"goptuna-example",
 		goptuna.StudyOptionStorage(rdb.NewStorage(db)),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 	)
 	if err != nil {
 		log.Fatal("failed to create a study:", err)

--- a/_examples/simple_rdb/main.go
+++ b/_examples/simple_rdb/main.go
@@ -40,7 +40,7 @@ func main() {
 		"rdb",
 		goptuna.StudyOptionStorage(storage),
 		goptuna.StudyOptionSampler(tpe.NewSampler()),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionLoadIfExists(true),
 	)
 	if err != nil {

--- a/_examples/trialnotify/main.go
+++ b/_examples/trialnotify/main.go
@@ -22,7 +22,7 @@ func main() {
 		"goptuna-example",
 		goptuna.StudyOptionSampler(tpe.NewSampler()),
 		goptuna.StudyOptionIgnoreError(true),
-		goptuna.StudyOptionSetTrialNotifyChannel(trialchan),
+		goptuna.StudyOptionTrialNotifyChannel(trialchan),
 	)
 
 	var wg sync.WaitGroup

--- a/logger.go
+++ b/logger.go
@@ -8,7 +8,7 @@ import (
 // Logger is the interface for logging messages.
 // If you want to log nothing, please set Logger as nil.
 // If you want to print more verbose logs,
-// it might StudyOptionSetTrialNotifyChannel option are useful.
+// it might StudyOptionTrialNotifyChannel option are useful.
 type Logger interface {
 	Debug(msg string, fields ...interface{})
 	Info(msg string, fields ...interface{})

--- a/medianstopping/percentile_test.go
+++ b/medianstopping/percentile_test.go
@@ -158,7 +158,7 @@ func TestPercentilePruner_Prune(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			study, err := goptuna.CreateStudy("", goptuna.StudyOptionSetDirection(tt.direction))
+			study, err := goptuna.CreateStudy("", goptuna.StudyOptionDirection(tt.direction))
 			if err != nil {
 				t.Errorf("should be err=nil, but got %s", err)
 				return

--- a/study_option.go
+++ b/study_option.go
@@ -64,8 +64,8 @@ func StudyOptionIgnoreError(ignore bool) StudyOption {
 	}
 }
 
-// StudyOptionSetTrialNotifyChannel to subscribe the finished trials.
-func StudyOptionSetTrialNotifyChannel(notify chan FrozenTrial) StudyOption {
+// StudyOptionTrialNotifyChannel to subscribe the finished trials.
+func StudyOptionTrialNotifyChannel(notify chan FrozenTrial) StudyOption {
 	return func(s *Study) error {
 		s.trialNotification = notify
 		return nil
@@ -96,3 +96,6 @@ var StudyOptionSetLogger = StudyOptionLogger
 // StudyOptionSetDirection change the direction of optimize
 // Deprecated: please use StudyOptionDirection instead.
 var StudyOptionSetDirection = StudyOptionDirection
+
+// StudyOptionSetTrialNotifyChannel to subscribe the finished trials.
+var StudyOptionSetTrialNotifyChannel = StudyOptionTrialNotifyChannel

--- a/study_option.go
+++ b/study_option.go
@@ -3,8 +3,8 @@ package goptuna
 // StudyOption to pass the custom option
 type StudyOption func(study *Study) error
 
-// StudyOptionSetDirection change the direction of optimize
-func StudyOptionSetDirection(direction StudyDirection) StudyOption {
+// StudyOptionDirection change the direction of optimize
+func StudyOptionDirection(direction StudyDirection) StudyOption {
 	return func(s *Study) error {
 		s.direction = direction
 		return nil
@@ -92,3 +92,7 @@ func StudyOptionDefineSearchSpace(space map[string]interface{}) StudyOption {
 // StudyOptionSetLogger sets Logger.
 // Deprecated: please use StudyOptionLogger instead.
 var StudyOptionSetLogger = StudyOptionLogger
+
+// StudyOptionSetDirection change the direction of optimize
+// Deprecated: please use StudyOptionDirection instead.
+var StudyOptionSetDirection = StudyOptionDirection

--- a/study_test.go
+++ b/study_test.go
@@ -43,7 +43,7 @@ func ExampleStudy_Optimize() {
 func TestStudy_SystemAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 
@@ -133,7 +133,7 @@ func TestStudy_EnqueueTrial_WithUnfixedParameter(t *testing.T) {
 func TestStudy_UserAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 
@@ -162,7 +162,7 @@ func TestStudy_UserAttrs(t *testing.T) {
 func TestStudy_AppendTrial(t *testing.T) {
 	study, err := goptuna.CreateStudy(
 		"example",
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	if err != nil {

--- a/successivehalving/pruner_test.go
+++ b/successivehalving/pruner_test.go
@@ -33,7 +33,7 @@ func TestOptunaPruner_IntermediateValues(t *testing.T) {
 				MinEarlyStoppingRate: 0,
 			}
 			study, err := goptuna.CreateStudy("optuna-pruner",
-				goptuna.StudyOptionSetDirection(tt.direction),
+				goptuna.StudyOptionDirection(tt.direction),
 				goptuna.StudyOptionPruner(pruner))
 			if err != nil {
 				t.Errorf("should be err=nil, but got %s", err)

--- a/tpe/sampler_test.go
+++ b/tpe/sampler_test.go
@@ -214,7 +214,7 @@ func TestSampler_SampleDiscreteUniform(t *testing.T) {
 func TestGetObservationPairs_MINIMIZE(t *testing.T) {
 	study, err := goptuna.CreateStudy(
 		"", goptuna.StudyOptionIgnoreError(true),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize))
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize))
 	if err != nil {
 		t.Errorf("should be nil, but got %s", err)
 		return
@@ -262,7 +262,7 @@ func TestGetObservationPairs_MAXIMIZE(t *testing.T) {
 	study, err := goptuna.CreateStudy(
 		"",
 		goptuna.StudyOptionIgnoreError(true),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMaximize))
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMaximize))
 	if err != nil {
 		t.Errorf("should be nil, but got %s", err)
 		return

--- a/trial_test.go
+++ b/trial_test.go
@@ -154,7 +154,7 @@ func TestTrial_UserAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
 		goptuna.StudyOptionStorage(goptuna.NewInMemoryStorage()),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	trialID, err := study.Storage.CreateNewTrial(study.ID)
@@ -193,7 +193,7 @@ func TestTrial_SystemAttrs(t *testing.T) {
 	study, _ := goptuna.CreateStudy(
 		"example",
 		goptuna.StudyOptionStorage(goptuna.NewInMemoryStorage()),
-		goptuna.StudyOptionSetDirection(goptuna.StudyDirectionMinimize),
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMinimize),
 		goptuna.StudyOptionSampler(goptuna.NewRandomSampler()),
 	)
 	trialID, err := study.Storage.CreateNewTrial(study.ID)


### PR DESCRIPTION
`StudyOptionSet...` is redundant and not consistent.

* sile/kurobako-go doesn't use these options.
* kubeflow/katib uses these options.

```
$ git grep StudyOptionSet ./pkg/suggestion/
pkg/suggestion/v1alpha3/goptuna/converter.go:   studyOpts = append(studyOpts, goptuna.StudyOptionSetDirection(direction))
pkg/suggestion/v1beta1/goptuna/converter.go:    studyOpts = append(studyOpts, goptuna.StudyOptionSetDirection(direction))
```