### PR TITLE
Include the upper bound of uniform/loguniform distributions

### DIFF
--- a/distribution.go
+++ b/distribution.go
@@ -49,7 +49,7 @@ func (d *UniformDistribution) Contains(ir float64) bool {
 	if d.Single() {
 		return ir == d.Low
 	}
-	return d.Low <= ir && ir < d.High
+	return d.Low <= ir && ir <= d.High
 }
 
 var _ Distribution = &LogUniformDistribution{}
@@ -80,7 +80,7 @@ func (d *LogUniformDistribution) Contains(ir float64) bool {
 	if d.Single() {
 		return ir == d.Low
 	}
-	return d.Low <= ir && ir < d.High
+	return d.Low <= ir && ir <= d.High
 }
 
 var _ Distribution = &IntUniformDistribution{}

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -251,6 +251,12 @@ func TestDistributionContains(t *testing.T) {
 			want:         true,
 		},
 		{
+			name:         "uniform distribution upper bound",
+			distribution: &goptuna.UniformDistribution{Low: 0.5, High: 5.5},
+			args:         5.5,
+			want:         true,
+		},
+		{
 			name:         "uniform distribution lower",
 			distribution: &goptuna.UniformDistribution{Low: 0.5, High: 5.5},
 			args:         -0.5,
@@ -265,7 +271,13 @@ func TestDistributionContains(t *testing.T) {
 		{
 			name:         "log uniform distribution true",
 			distribution: &goptuna.LogUniformDistribution{Low: 1e-1, High: 1e3},
-			args:         float64(1e2),
+			args:         1e2,
+			want:         true,
+		},
+		{
+			name:         "log uniform distribution upper bound",
+			distribution: &goptuna.LogUniformDistribution{Low: 1e-1, High: 1e3},
+			args:         1e2,
 			want:         true,
 		},
 		{


### PR DESCRIPTION
See https://github.com/optuna/optuna/pull/2223

> In the current specification of UniformDistribution and LogUniformDistribution, the upper bounds are excluded.
> This behavior is based on the specification of stdlib and/or numpy random modules. But it confuses the users and the developers in some situation.