### PR TITLE
Add options to skip initial portion of Sobol' sequence

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -94,7 +94,7 @@ type RandomSampler struct {
 	mu  sync.Mutex
 }
 
-// RandomSamplerOption is a type of function to set change the option.
+// RandomSamplerOption is a type of function to set options.
 type RandomSamplerOption func(sampler *RandomSampler)
 
 // RandomSamplerOptionSeed sets seed number.

--- a/sobol/engine.go
+++ b/sobol/engine.go
@@ -14,6 +14,24 @@ func findRightmostZeroBit(n uint32) uint32 {
 	return c + 1 // starts from 1
 }
 
+func getNumberOfSkippedPoints(n uint32) uint32 {
+	// In the 3-page notes of Joe & Kuo, they said:
+	//
+	// > It has been recommended by some that the Sobol0 sequence tends to perform better
+	// > if an initial portion of the sequence is dropped: the number of points skipped is
+	// > the largest power of 2 smaller than the number of points to be used.
+	// > However, we are less persuaded by such recommendation ourselves.
+	cnt := uint32(0)
+	for {
+		n >>= 1
+		if n == 0 {
+			break
+		}
+		cnt++
+	}
+	return uint32(math.Pow(2, float64(cnt)))
+}
+
 func initDirectionNumbers(dim uint32) [][]uint32 {
 	v := make([][]uint32, dim)
 	for i := uint32(0); i < dim; i++ {

--- a/sobol/engine_test.go
+++ b/sobol/engine_test.go
@@ -35,3 +35,38 @@ func Test_findRightmostZeroBit(t *testing.T) {
 		})
 	}
 }
+
+func Test_getNumberOfSkippedPoints(t *testing.T) {
+	tests := []struct {
+		n        uint32
+		expected uint32
+	}{
+		{
+			n:        2,
+			expected: 2,
+		},
+		{
+			n:        7,
+			expected: 4,
+		},
+		{
+			n:        8,
+			expected: 8,
+		},
+		{
+			n:        10,
+			expected: 8,
+		},
+		{
+			n:        20,
+			expected: 16,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			if got := getNumberOfSkippedPoints(tt.n); got != tt.expected {
+				t.Errorf("skippedPoints(%d) = %v, expected %v", tt.n, got, tt.expected)
+			}
+		})
+	}
+}

--- a/sobol/sampler.go
+++ b/sobol/sampler.go
@@ -38,7 +38,7 @@ func (s *Sampler) SampleRelative(study *goptuna.Study, trial goptuna.FrozenTrial
 	dim := len(searchSpace)
 	if s.engine == nil {
 		s.engine = NewEngine(uint32(dim))
-		for i := uint32(0); i<s.numSkip; i++ {
+		for i := uint32(0); i < s.numSkip; i++ {
 			s.engine.Draw()
 		}
 	} else {

--- a/sobol/sampler.go
+++ b/sobol/sampler.go
@@ -10,8 +10,27 @@ import (
 var _ goptuna.RelativeSampler = &Sampler{}
 
 // Sampler for quasi-Monte Carlo Sampling based on Sobol sequence.
+// It is recommended to use "SamplerOptionSkipInitialPoints(n)" for better performance.
+// Furthermore, if you use this sampler from multiple workers, you need to specify
+// different "n" argument for each workers to remove duplicated parameters.
 type Sampler struct {
-	engine *Engine
+	engine  *Engine
+	numSkip uint32
+}
+
+// SamplerOption is a type of function to set options.
+type SamplerOption func(sampler *Sampler)
+
+// SamplerOptionSkipInitialPoints to skip the number of initial points.
+// Joe&Kuo recommended to drop initial portion of sequence.
+// Thereby, Sobol' sequence tends to perform better.
+// This function takes 'nSamples' argument which is the number of points to be
+// used (= the number of objective function calls), then skips the largest
+// power of 2 points smaller than nSample.
+func SamplerOptionSkipInitialPoints(nSamples uint32) SamplerOption {
+	return func(sampler *Sampler) {
+		sampler.numSkip = getNumberOfSkippedPoints(nSamples)
+	}
 }
 
 // SampleRelative samples multiple dimensional parameters in a given search space.
@@ -19,6 +38,9 @@ func (s *Sampler) SampleRelative(study *goptuna.Study, trial goptuna.FrozenTrial
 	dim := len(searchSpace)
 	if s.engine == nil {
 		s.engine = NewEngine(uint32(dim))
+		for i := uint32(0); i<s.numSkip; i++ {
+			s.engine.Draw()
+		}
 	} else {
 		// Detect dynamic search space.
 		if s.engine.dim != uint32(dim) {
@@ -68,7 +90,8 @@ func (s *Sampler) SampleRelative(study *goptuna.Study, trial goptuna.FrozenTrial
 // NewSampler returns the Sobol sampler.
 func NewSampler() *Sampler {
 	sampler := &Sampler{
-		engine: nil,
+		engine:  nil,
+		numSkip: 0,
 	}
 	return sampler
 }


### PR DESCRIPTION
From the note of Joe & Kuo:

> It has been recommended by some that the Sobol0 sequence tends to perform better if an initial portion of the sequence is dropped: the number of points skipped is the largest power of 2 smaller than the number of points to be used. However, we are less persuaded by such recommendation ourselves.

So I add a sampler option to skip initial portion of sequence.