### PR TITLE
Faster findRightmostZeroBit

### DIFF
--- a/sobol/engine.go
+++ b/sobol/engine.go
@@ -3,15 +3,13 @@ package sobol
 import (
 	"fmt"
 	"math"
+	"math/bits"
 )
 
 // findRightmostZeroBit returns index from the right of the first zero bit of n.
 func findRightmostZeroBit(n uint32) uint32 {
-	c := uint32(0)
-	for n&(1<<c) != 0 {
-		c++
-	}
-	return c + 1 // starts from 1
+	n = ^n
+	return uint32(bits.OnesCount32((n & -n) - 1)) + 1
 }
 
 func getNumberOfSkippedPoints(n uint32) uint32 {

--- a/sobol/engine_test.go
+++ b/sobol/engine_test.go
@@ -36,6 +36,26 @@ func Test_findRightmostZeroBit(t *testing.T) {
 	}
 }
 
+func BenchmarkFindRightmostZeroBit(b *testing.B) {
+	for n := uint32(0); n < uint32(b.N); n++ {
+		findRightmostZeroBit(n)
+	}
+}
+
+func BenchmarkOldFindRightmostZeroBit(b *testing.B) {
+	old := func(n uint32) uint32 {
+		c := uint32(0)
+		for n&(1<<c) != 0 {
+			c++
+		}
+		return c + 1 // starts from 1
+	}
+
+	for n := uint32(0); n < uint32(b.N); n++ {
+		old(n)
+	}
+}
+
 func Test_getNumberOfSkippedPoints(t *testing.T) {
 	tests := []struct {
 		n        uint32


### PR DESCRIPTION
```
BenchmarkFindRightmostZeroBit-12        1000000000               0.509 ns/op           0 B/op          0 allocs/op
BenchmarkOldFindRightmostZeroBit-12     428957529                2.73 ns/op            0 B/op          0 allocs/op
```