### PR TITLE
Fix a small error in Sobol engine

### DIFF
--- a/sobol/engine.go
+++ b/sobol/engine.go
@@ -33,11 +33,11 @@ func getNumberOfSkippedPoints(n uint32) uint32 {
 func initDirectionNumbers(dim uint32) [][]uint32 {
 	v := make([][]uint32, dim)
 	for i := uint32(0); i < dim; i++ {
-		v[i] = make([]uint32, maxBit)
+		v[i] = make([]uint32, maxBit+1)
 	}
 
 	// First row of sobol state is all '1'.
-	for m := 0; m < maxBit; m++ {
+	for m := 0; m <= maxBit; m++ {
 		v[0][m] = 1 << (32 - m) // all m's = 1
 	}
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!

If your patch contains file changes under the `dashboard/` directory,
please uncomment "Contributor License Agreement" section and place a check mark.
-->

<!--
## Contributor License Agreement for Web Dashboard

This repository (``Goptuna``) and [optuna-dashboard](https://github.com/optuna/optuna-dashboard) share common code of Web Dashboard.
This pull request may therefore be ported to `optuna-dashboard`.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [optuna-dashboard](https://github.com/optuna/optuna-dashboard) by other `optuna-dashboard` contributors.
-->

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
The initial direction number of Sobol engine is not rectangular. This is likely unintentional.
